### PR TITLE
Allow function calls in parameters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -22,6 +22,8 @@ ignore=
     ANN002,ANN003,ANN101,ANN102,ANN204,ANN206
     # Imports
     I202, I201, I100
+    # Function calls in argument defaults
+    B008
 
 per-file-ignores=
     app/models/__init__.py:F401


### PR DESCRIPTION
This is commonly done in the FastAPI framework, we shouldn't warn for it