### PR TITLE
add blog links to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,15 @@ prisma migrate dev --schema prisma/schema.prisma --name "what this change does"
 ```
 
 ## Pre-commit
+
 Install pre-commit to make sure you never fail linting in CI.
 
 ```shell
 poetry run pre-commit install
 ```
+
+## More Info
+
+If you would like to learn more, we provide guides and details about this template and the related technologies on our [blog](https://blog.abandontech.cloud/)
+
+Consider taking a look at our [guide for this template](https://blog.abandontech.cloud/easy-python-web-backend-using-fastapi-postgres-and-prisma/)


### PR DESCRIPTION
The abandon tech blog will contain various guides/thoughts on things we use and find interesting. Currently we have one guide specifically dedicated to using this template. In the future we should have more relevant posts regarding the technologies on this template.